### PR TITLE
chore(renovate): adjust post upgrade tasks to allow automatic sha-sum update

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,7 +18,7 @@
     },
   ],
   postUpgradeTasks: {
-    commands: ['bash .github/renovate/create_ec2_install_checksum.sh'],
+    commands: ['bash .github/renovate/post-upgrade.sh'],
     fileFilters: [ 'AWS/EC2/ec2-install.sh', ],
     executionMode: 'branch',
   },

--- a/.github/renovate/create_ec2_install_checksum.sh
+++ b/.github/renovate/create_ec2_install_checksum.sh
@@ -1,18 +1,6 @@
 #!/bin/bash
-# Create sha256 checksum for the installation script
 
-set -Eeuo pipefail
+echo "Update sha256 checksum file for AWS script"
 
-setup_colors() {
-  if [[ -t 2 ]] && [[ -z "${NO_COLOR-}" ]] && [[ "${TERM-}" != "dumb" ]]; then
-    NOFORMAT='\033[0m' RED='\033[0;31m' GREEN='\033[0;32m' ORANGE='\033[0;33m' BLUE='\033[0;34m' PURPLE='\033[0;35m' CYAN='\033[0;36m' YELLOW='\033[1;33m'
-  else
-    NOFORMAT='' RED='' GREEN='' ORANGE='' BLUE='' PURPLE='' CYAN='' YELLOW=''
-  fi
-}
-
-setup_colors
-
-# Script logic
-msg "${YELLOW}Creating checksum${NOFORMAT}"
+cd "AWS/EC2"
 sha256sum ec2-install.sh > ec2-install.sh.sha256

--- a/.github/renovate/post-upgrade.sh
+++ b/.github/renovate/post-upgrade.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+bash .github/renovate/create_ec2_install_checksum.sh


### PR DESCRIPTION
A simplification of the checksum script has been made to be compatible with renovate
update process and eventually installations without specific binaries (`msg`).

Related to #51910
