### PR TITLE
chore(scripts): Update tested Ubuntu version from 24.04 to 26.04

### DIFF
--- a/AWS/EC2/ec2-install.sh
+++ b/AWS/EC2/ec2-install.sh
@@ -90,7 +90,7 @@ echo -e "\n${WHITE}${BOLD}Example: ./install.sh -l develocity.license -hn develo
 echo -e "\nThe script sets up a lightweight Kubernetes (K3s) environment in which Develocity is deployed using Helm."
 echo -e "The license (-l, --license) and hostname (-hn, --hostname) flags are always required."
 
-echo -e "\nThe script is tested with Ubuntu 24.04 x86_64 (AMI)."
+echo -e "\nThe script is tested with Ubuntu 26.04 x86_64 (AMI)."
 
 echo -e "If you have questions please contact the Develocity support team."
 


### PR DESCRIPTION
## Summary

- Update the usage text in `ec2-install.sh` from Ubuntu 24.04 to 26.04 to match the AMI now referenced in the EC2 quickstart guide

## Context

The EC2 quickstart guide was updated in gradle/dv-docs#1788 to reference the Ubuntu 26.04 LTS AMI. The usage string in `ec2-install.sh` still said "tested with Ubuntu 24.04", which is now stale and misleading.